### PR TITLE
Bump podspec/README version to 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Set up the `clientId`, `appSecret` and `customerIdentifier` constants to your Cl
 
 ## Versioning
 
-The current version of the SDK is [2.5.5](https://github.com/saltedge/saltedge-ios/releases/tag/v2.5.5), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/#version_management). Any backward-incompatible changes in the API will result in changes to the SDK.
+The current version of the SDK is [2.6.0](https://github.com/saltedge/saltedge-ios/releases/tag/v2.6.0), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/#version_management). Any backward-incompatible changes in the API will result in changes to the SDK.
 
 ## License
 

--- a/SaltEdge-iOS.podspec
+++ b/SaltEdge-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SaltEdge-iOS"
-  s.version      = "2.5.5"
+  s.version      = "2.6.0"
   s.summary      = "A handful of classes to help you interact with the Salt Edge API from your iOS app."
 
   s.description  = <<-DESC
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "https://github.com/saltedge/saltedge-ios"
   s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v2.5.5" }
+  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v2.6.0" }
   s.source_files = 'Classes/**/**.{h,m}'
   s.requires_arc = true
   s.author       = "SaltEdge"


### PR DESCRIPTION
**Reference:** :no_entry_sign: 

```
  - Data URL: https://raw.githubusercontent.com/CocoaPods/Specs/cc0a15831972059a01b2ca672eedecda9ab78bc4/Specs/SaltEdge-iOS/2.6.0/SaltEdge-iOS.podspec.json
  - Log messages:
    - January 6th, 13:08: Push for `SaltEdge-iOS 2.6.0' initiated.
    - January 6th, 13:08: Push for `SaltEdge-iOS 2.6.0' has been pushed (1.100158313 s).
```