### PR TITLE
Bump podspec version to 3.1.1, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the pod to your `Podfile`
 # ... snip ...
 
 # To use Spectre API v3
-pod 'SaltEdge-iOS', '~> 3.1.0'
+pod 'SaltEdge-iOS', '~> 3.1.1'
 
 # To use Spectre API v2
 pod 'SaltEdge-iOS', '~> 2.6.0'
@@ -268,7 +268,7 @@ Set up the `clientId`, `appSecret` and `customerIdentifier` constants to your Cl
 
 ## Versioning
 
-The current version of the SDK is [3.1.0](https://github.com/saltedge/saltedge-ios/releases/tag/v3.1.0), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
+The current version of the SDK is [3.1.1](https://github.com/saltedge/saltedge-ios/releases/tag/v3.1.1), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
 
 ## License
 

--- a/SaltEdge-iOS.podspec
+++ b/SaltEdge-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SaltEdge-iOS"
-  s.version      = "3.1.0"
+  s.version      = "3.1.1"
   s.summary      = "A handful of classes to help you interact with the Salt Edge API from your iOS app."
 
   s.description  = <<-DESC
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "https://github.com/saltedge/saltedge-ios"
   s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.1.0" }
+  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.1.1" }
   s.source_files = 'Classes/**/**.{h,m}'
   s.requires_arc = true
   s.author       = "SaltEdge"


### PR DESCRIPTION
**Reference:** 🚫 

```
  - Data URL: https://raw.githubusercontent.com/CocoaPods/Specs/eeb84ff8c9f5fc7bda73358444a640cf7819cbd6/Specs/SaltEdge-iOS/3.1.1/SaltEdge-iOS.podspec.json
  - Log messages:
    - August 2nd, 18:19: Push for `SaltEdge-iOS 3.1.1' initiated.
    - August 2nd, 18:19: Push for `SaltEdge-iOS 3.1.1' has been pushed (0.567606048 s).
```