### PR TITLE
Bump version to 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the pod to your `Podfile`
 # ... snip ...
 
 # To use Spectre API v3
-pod 'SaltEdge-iOS', '~> 3.1.1'
+pod 'SaltEdge-iOS', '~> 3.1.2'
 
 # To use Spectre API v2
 pod 'SaltEdge-iOS', '~> 2.6.0'
@@ -268,7 +268,7 @@ Set up the `clientId`, `appSecret` and `customerIdentifier` constants to your Cl
 
 ## Versioning
 
-The current version of the SDK is [3.1.1](https://github.com/saltedge/saltedge-ios/releases/tag/v3.1.1), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
+The current version of the SDK is [3.1.2](https://github.com/saltedge/saltedge-ios/releases/tag/v3.1.2), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
 
 ## Security
 

--- a/SaltEdge-iOS.podspec
+++ b/SaltEdge-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SaltEdge-iOS"
-  s.version      = "3.1.1"
+  s.version      = "3.1.2"
   s.summary      = "A handful of classes to help you interact with the Salt Edge API from your iOS app."
 
   s.description  = <<-DESC
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "https://github.com/saltedge/saltedge-ios"
   s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.1.1" }
+  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.1.2" }
   s.source_files = 'Classes/**/**.{h,m}'
   s.requires_arc = true
   s.author       = "SaltEdge"


### PR DESCRIPTION
**Reference:** addendum to #72 

```
- Data URL: https://raw.githubusercontent.com/CocoaPods/Specs/2e77bbbee6b3292b9a680732823404e24bdb1731/Specs/SaltEdge-iOS/3.1.2/SaltEdge-iOS.podspec.json
  - Log messages:
    - October 19th, 12:21: Push for `SaltEdge-iOS 3.1.2' initiated.
    - October 19th, 12:21: Push for `SaltEdge-iOS 3.1.2' has been pushed (0.392644446 s).
```