### PR TITLE
Bump build numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the pod to your `Podfile`
 # ... snip ...
 
 # To use Spectre API v3
-pod 'SaltEdge-iOS', '~> 3.2.2'
+pod 'SaltEdge-iOS', '~> 3.2.3'
 
 # To use Spectre API v2
 pod 'SaltEdge-iOS', '~> 2.6.0'
@@ -268,7 +268,7 @@ Set up the `clientId`, `appSecret` and `customerIdentifier` constants to your Cl
 
 ## Versioning
 
-The current version of the SDK is [3.2.2](https://github.com/saltedge/saltedge-ios/releases/tag/v3.2.2), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
+The current version of the SDK is [3.2.3](https://github.com/saltedge/saltedge-ios/releases/tag/v3.2.3), and is in compliance with the Salt Edge API's [current version](https://docs.saltedge.com/guides/versioning/). Any backward-incompatible changes in the API will result in changes to the SDK.
 
 ## Security
 

--- a/SaltEdge-iOS.podspec
+++ b/SaltEdge-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SaltEdge-iOS"
-  s.version      = "3.2.2"
+  s.version      = "3.2.3"
   s.summary      = "A handful of classes to help you interact with the Salt Edge API from your iOS app."
 
   s.description  = <<-DESC
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage     = "https://github.com/saltedge/saltedge-ios"
   s.license      = { :type => "MIT", :file => "LICENSE" }
-  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.2.2" }
+  s.source       = { :git => "https://github.com/saltedge/saltedge-ios.git", :tag => "v3.2.3" }
   s.source_files = 'Classes/**/**.{h,m}'
   s.requires_arc = true
   s.author       = "SaltEdge"


### PR DESCRIPTION
**Reference:** 🚫 

 🎉  Congrats

 🚀  SaltEdge-iOS (3.2.3) successfully published
 📅  October 31st, 12:01
 🌎  https://cocoapods.org/pods/SaltEdge-iOS
 👍  Tell your friends!